### PR TITLE
Enable mode7 explicitly

### DIFF
--- a/metadata/service/client/init.yml
+++ b/metadata/service/client/init.yml
@@ -12,3 +12,4 @@ parameters:
       strata:
       - ${_param:ntp_strata_host1}
       - ${_param:ntp_strata_host2}
+      mode7: false

--- a/ntp/files/ntp.conf
+++ b/ntp/files/ntp.conf
@@ -25,6 +25,10 @@ restrict default noquery nopeer
 
 restrict 127.0.0.1
 restrict ::1
+{%- if ntp.mode7 %}
+# mode7 is required for collectd monitoring
+enable mode7
+{%- endif %}
 
 # Location of drift file
 driftfile /var/lib/ntp/ntp.drift

--- a/ntp/map.jinja
+++ b/ntp/map.jinja
@@ -2,12 +2,15 @@
 {% set client = salt['grains.filter_by']({
     'Arch': {
         'service': 'ntpd',
+        'mode7': False,
     },
     'Debian': {
         'service': 'ntp',
+        'mode7': False,
     },
     'RedHat': {
         'service': 'ntpd',
+        'mode7': False,
     },
 }, merge=salt['pillar.get']('ntp:client')) %}
 

--- a/ntp/meta/collectd.yml
+++ b/ntp/meta/collectd.yml
@@ -1,4 +1,8 @@
+{% from "ntp/map.jinja" import client with context %}
+
+{%- if client.get('enabled', False) and client.mode7 %}
 local_plugin:
   ntp_server_status:
     plugin: ntpd
     template: ntp/files/collectd_ntpd.conf
+{%- endif %}


### PR DESCRIPTION
collectd failed to monitor ntpd on Xenial servers because it uses mode7
requests but newer ntpd releases (4.2.7p230 and later) disable this mode
by default for security reasons. Since the ntpd configuration only
allows queries from the 127.0.0.1 address, it is reasonably safe to
enable mode7 requests though.