### PR TITLE
fix missing ntp variable error

### DIFF
--- a/ntp/files/ntp.conf
+++ b/ntp/files/ntp.conf
@@ -20,7 +20,7 @@ restrict default noquery nopeer
 
 restrict 127.0.0.1
 restrict ::1
-{%- if ntp.mode7 %}
+{%- if client.get('mode7') %}
 # mode7 is required for collectd monitoring
 enable mode7
 {%- endif %}


### PR DESCRIPTION
It was failing with: 

```
----------
          ID: /etc/ntp.conf
    Function: file.managed
      Result: False
     Comment: Unable to manage file: Jinja variable 'ntp' is undefined
     Started: 11:58:05.396994
    Duration: 37.777 ms
     Changes:   
```

cc @epcim @fpytloun 
