### PR TITLE
Jinja processing fix for pillar data

### DIFF
--- a/ntp/files/ntp.conf
+++ b/ntp/files/ntp.conf
@@ -9,13 +9,13 @@
 # - https://wiki.archlinux.org/index.php/Network_Time_Protocol_daemon
 
 # Associate to cloud NTP pool servers
-{%- if client.get('enabled', True) %}
+{%- if client.get('enabled', False) %}
 {%- for stratum in client.strata %}
 server {{ stratum }}{% if loop.first %} iburst{% endif %}
 {%- endfor %}
 {%- endif %}
 
-{%- if server.get('enabled', True) %}
+{%- if server.get('enabled', False) %}
 {%- for stratum in server.strata %}
 server {{ stratum }}{% if loop.first %} iburst{% endif %}
 {%- endfor %}

--- a/ntp/map.jinja
+++ b/ntp/map.jinja
@@ -5,7 +5,7 @@
     },
     'Debian': {
         'service': 'ntp',
-        'mode7': False
+        'mode7': False,
     },
     'RedHat': {
         'service': 'ntpd',

--- a/tests/pillar/client.sls
+++ b/tests/pillar/client.sls
@@ -2,8 +2,5 @@ ntp:
   client:
     enabled: true
     strata:
-    - ntp-01
-    - ntp-02
-  server:
-    enabled: false
-    mode7: false
+    - ntp.cesnet.cz
+    - pool.ntp.org

--- a/tests/pillar/server.sls
+++ b/tests/pillar/server.sls
@@ -9,13 +9,10 @@ ntp:
         mask: 255.255.255.0
       - subnet: 172.16.1.1
         mask: 255.255.0.0
+        options: notrap nomodify
     mode7: true
     peers:
       - 192.168.31.1
       - 192.168.31.2
       - 192.168.31.3
     orphan: 5
-  client:
-    enabled: false
-    strata:
-    - ""


### PR DESCRIPTION
Error during salt-formula execution `Unable to manage file: Jinja variable 'dict object' has no attribute 'strata'` occur if pillar data does not contain both server and client definitions for strata. 
This is fixed by modifying `.get('enabled', True)` to `.get('enabled', False)` in /ntp/files/ntp.conf
There is no need to have both definitions for client and server so /tests/pillar/client.sls and /tests/pillar/server.sls file were updated to reflect that fact.

I have also noticed missing comma in /ntp/map.jinja

Thanks