### PR TITLE
We should be able to define interface behaviors if NTP is a client too

### DIFF
--- a/ntp/files/ntp.conf
+++ b/ntp/files/ntp.conf
@@ -15,6 +15,12 @@
 logfile {{ client.logfile }}
 {%- endif %}
 
+{%- if client.interface is defined and client.interface != None %}
+{%- for _, iface in client.interface.items() %}
+interface {{ iface.action }} {{ iface.value }}
+{%- endfor -%}
+{%- endif -%}
+
 {%- if client.stratum is defined %}
 {%- for stratum_name, stratum in client.stratum.items() %}
 server {{ stratum.server }} {%- if stratum.get('key_id') %} key {{ stratum.key_id }} {%- endif %} {%- if loop.first %} iburst{%- endif %}


### PR DESCRIPTION
There is a use case to define interface behavior when the NTP service is acting as a client and not as a server. These changes enable this configuration when using NTP as a client and when defining the service as a client in the pillar.