### PR TITLE
Fix syntax error in ntp.conf template

### DIFF
--- a/ntp/files/ntp.conf
+++ b/ntp/files/ntp.conf
@@ -40,17 +40,7 @@ server {{ server_args|join(' ') }}
 {%- endfor %}
 {%- else %}
 {%- for stratum in client.strata %}
-{%-   set server_args = [stratum.server] %}
-{%-   if loop.first and stratum.get('iburst', True) %}
-{%-     do server_args.extend(['iburst']) %}
-{%-   endif %}
-{%-   if stratum.get('minpoll') %}
-{%-     do server_args.extend(['minpoll', stratum.minpoll]) %}
-{%-   endif %}
-{%-   if stratum.get('maxpoll') %}
-{%-     do server_args.extend(['maxpoll', stratum.maxpoll]) %}
-{%-   endif %}
-server {{ server_args|join(' ') }}
+server {{ stratum }}{%- if loop.first %} iburst{%- endif %}
 {%- endfor %}
 {%- endif -%}
 
@@ -70,7 +60,7 @@ interface {{ iface.action }} {{ iface.value }}
 
 {%- if server.stratum is defined %}
 {%- for stratum_name, stratum in server.stratum.items() %}
-{%-   set server_args = [] %}
+{%-   set server_args = [stratum.server] %}
 {%-   if stratum.get('key_id') %}
 {%-     do server_args.extend(['key', stratum.key_id]) %}
 {%-   endif %}
@@ -87,17 +77,7 @@ server {{ server_args|join(' ') }}
 {%- endfor %}
 {%- else %}
 {%- for stratum in server.strata %}
-{%-   set server_args = [] %}
-{%-   if loop.first and stratum.get('iburst', True) %}
-{%-     do server_args.extend(['iburst']) %}
-{%-   endif %}
-{%-   if stratum.get('minpoll') %}
-{%-     do server_args.extend(['minpoll', stratum.minpoll]) %}
-{%-   endif %}
-{%-   if stratum.get('maxpoll') %}
-{%-     do server_args.extend(['maxpoll', stratum.maxpoll]) %}
-{%-   endif %}
-server {{ server_args|join(' ') }}
+server {{ stratum }}{%- if loop.first %} iburst{%- endif %}
 {%- endfor %}
 {%- endif -%}
 


### PR DESCRIPTION
This fixes a syntax error in the previous commit:
- the 'deprecated' pillar configuration using 'strata' didn't work anymore, because the list was used as a dictionary
- the server side configuration was missing the actual reference to a server